### PR TITLE
fix: disposable commit_message_generator

### DIFF
--- a/lib/aicommit.rb
+++ b/lib/aicommit.rb
@@ -56,6 +56,6 @@ class Aicommit
   end
 
   def commit_message_generator
-    @_commit_message_generator ||= CommitMessageGenerator.new(@token_manager.fetch("OPENAI_API_TOKEN"))
+    @_commit_message_generator = CommitMessageGenerator.new(@token_manager.fetch("OPENAI_API_TOKEN"))
   end
 end

--- a/spec/aicommit_spec.rb
+++ b/spec/aicommit_spec.rb
@@ -9,23 +9,36 @@ describe Aicommit do
     allow(GitClient).to receive(:new).and_return(git_client)
     allow(CommitMessageGenerator).to receive(:new).and_return(commit_message_generator)
     allow(TokenManager).to receive(:new).and_return(token_manager)
-    allow(token_manager).to receive(:fetch).with("OPENAI_API_TOKEN").and_return("API_KEY")
   end
 
   describe "#run" do
-    it "shows hint commit message and ask user if commit or not" do
-      expect(git_client).to receive(:get_patch_str).and_return("diff")
+    context "when invalid api token" do
+      before do
+        allow(token_manager).to receive(:fetch).with("OPENAI_API_TOKEN").and_return("INVALID_API_KEY", "VALID_API_KEY")
+      end
 
-      expect(commit_message_generator).to receive(:generate).with("diff").and_return({code: 200, result: "commit message"})
+      it "asks for valid api token and save" do
+        expect(git_client).to receive(:get_patch_str).and_return("diff")
 
-      allow(subject).to receive(:gets).and_return("Y\n")
-      expect(git_client).to receive(:commit_all).with("commit message")
+        expect(CommitMessageGenerator).to receive(:new).with("INVALID_API_KEY").and_return(commit_message_generator)
+        expect(CommitMessageGenerator).to receive(:new).with("VALID_API_KEsY").and_return(commit_message_generator)
 
-      expect { subject.run }.to output(/commit_message: commit message/).to_stdout.and(raise_error(SystemExit))
+        expect(commit_message_generator).to receive(:generate).with("diff").and_return({code: 401, result: ""}, {code: 200, result: "commit message"})
+        expect(token_manager).to receive(:write!).with("OPENAI_API_TOKEN")
+
+        allow(subject).to receive(:gets).and_return("VALID_API_KEY\n", "Y\n")
+        expect(git_client).to receive(:commit_all).with("commit message")
+
+        expect { subject.run }.to output(/Invalid API key./).to_stdout.and(raise_error(SystemExit))
+      end
     end
 
-    context "when input is Y" do
-      it "tells user what commit message would be then commit and exit program" do
+    context "when valid api token" do
+      before do
+        allow(token_manager).to receive(:fetch).with("OPENAI_API_TOKEN").and_return("API_KEY")
+      end
+
+      it "shows hint commit message and ask user if commit or not" do
         expect(git_client).to receive(:get_patch_str).and_return("diff")
 
         expect(commit_message_generator).to receive(:generate).with("diff").and_return({code: 200, result: "commit message"})
@@ -33,54 +46,67 @@ describe Aicommit do
         allow(subject).to receive(:gets).and_return("Y\n")
         expect(git_client).to receive(:commit_all).with("commit message")
 
-        expect { subject.run }.to output(/Committed all changes with message: commit message/).to_stdout.and(raise_error(SystemExit))
+        expect { subject.run }.to output(/commit_message: commit message/).to_stdout.and(raise_error(SystemExit))
       end
-    end
 
-    context "when input is R" do
-      it "regenerates commit message" do
-        expect(git_client).to receive(:get_patch_str).and_return("diff")
-        expect(commit_message_generator).to receive(:generate).with("diff").and_return({code: 200, result: "commit message"}, {code: 200, result: "new commit message"})
+      context "when input is Y" do
+        it "tells user what commit message would be then commit and exit program" do
+          expect(git_client).to receive(:get_patch_str).and_return("diff")
 
-        allow(subject).to receive(:gets).and_return("R\n", "Y\n")
-        expect(git_client).to receive(:commit_all).with("new commit message")
+          expect(commit_message_generator).to receive(:generate).with("diff").and_return({code: 200, result: "commit message"})
 
-        expect { subject.run }.to output(/commit_message: new commit message/).to_stdout.and(raise_error(SystemExit))
+          allow(subject).to receive(:gets).and_return("Y\n")
+          expect(git_client).to receive(:commit_all).with("commit message")
+
+          expect { subject.run }.to output(/Committed all changes with message: commit message/).to_stdout.and(raise_error(SystemExit))
+        end
       end
-    end
 
-    context "when input is N" do
-      it "allows user to overwrite commit message" do
-        expect(git_client).to receive(:get_patch_str).and_return("diff")
-        expect(commit_message_generator).to receive(:generate).with("diff").and_return({code: 200, result: "commit message"})
+      context "when input is R" do
+        it "regenerates commit message" do
+          expect(git_client).to receive(:get_patch_str).and_return("diff")
+          expect(commit_message_generator).to receive(:generate).with("diff").and_return({code: 200, result: "commit message"}, {code: 200, result: "new commit message"})
 
-        allow(subject).to receive(:gets).and_return("N\n", "new commit message\n", "Y\n")
-        expect(git_client).to receive(:commit_all).with("new commit message")
+          allow(subject).to receive(:gets).and_return("R\n", "Y\n")
+          expect(git_client).to receive(:commit_all).with("new commit message")
 
-        expect { subject.run }.to output(/commit_message: new commit message/).to_stdout.and(raise_error(SystemExit))
+          expect { subject.run }.to output(/commit_message: new commit message/).to_stdout.and(raise_error(SystemExit))
+        end
       end
-    end
 
-    context "when input is Q" do
-      it "quits without commit" do
-        expect(git_client).to receive(:get_patch_str).and_return("diff")
-        expect(commit_message_generator).to receive(:generate).with("diff").and_return({code: 200, result: "commit message"})
+      context "when input is N" do
+        it "allows user to overwrite commit message" do
+          expect(git_client).to receive(:get_patch_str).and_return("diff")
+          expect(commit_message_generator).to receive(:generate).with("diff").and_return({code: 200, result: "commit message"})
 
-        allow(subject).to receive(:gets).and_return("Q\n")
+          allow(subject).to receive(:gets).and_return("N\n", "new commit message\n", "Y\n")
+          expect(git_client).to receive(:commit_all).with("new commit message")
 
-        expect { subject.run }.to output(/Quit without committing/).to_stdout.and(raise_error(SystemExit))
+          expect { subject.run }.to output(/commit_message: new commit message/).to_stdout.and(raise_error(SystemExit))
+        end
       end
-    end
 
-    context "when input is not Y, R, N, Q" do
-      it "shows warning message and loops again" do
-        expect(git_client).to receive(:get_patch_str).and_return("diff")
+      context "when input is Q" do
+        it "quits without commit" do
+          expect(git_client).to receive(:get_patch_str).and_return("diff")
+          expect(commit_message_generator).to receive(:generate).with("diff").and_return({code: 200, result: "commit message"})
 
-        allow(subject).to receive(:gets).and_return("invalid\n", "Y\n")
-        expect(commit_message_generator).to receive(:generate).with("diff").and_return({code: 200, result: "commit message"})
-        expect(git_client).to receive(:commit_all).with("commit message")
+          allow(subject).to receive(:gets).and_return("Q\n")
 
-        expect { subject.run }.to output(/Invalid command/).to_stdout.and(raise_error(SystemExit))
+          expect { subject.run }.to output(/Quit without committing/).to_stdout.and(raise_error(SystemExit))
+        end
+      end
+
+      context "when input is not Y, R, N, Q" do
+        it "shows warning message and loops again" do
+          expect(git_client).to receive(:get_patch_str).and_return("diff")
+
+          allow(subject).to receive(:gets).and_return("invalid\n", "Y\n")
+          expect(commit_message_generator).to receive(:generate).with("diff").and_return({code: 200, result: "commit message"})
+          expect(git_client).to receive(:commit_all).with("commit message")
+
+          expect { subject.run }.to output(/Invalid command/).to_stdout.and(raise_error(SystemExit))
+        end
       end
     end
   end


### PR DESCRIPTION
modify to disposable commit_message_generator for updated open_ai_token by the user