### PR TITLE
fix: add gem install bundler -v 2.4.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          gem install bundler
+          gem install bundler -v 2.4.22
           bundle install
       - name: Run RSpec
         run: bundle exec rspec


### PR DESCRIPTION
- add gem install bundler -v 2.4.22

issue: [CI failed](https://github.com/jackal998/aicommit/actions/runs/7239330968/job/19721071535?pr=31)
![image](https://github.com/jackal998/aicommit/assets/22932376/348c2ea5-b442-47ec-98b7-ecbc01363aca)
