### PR TITLE
fix: add wsl compatibility and required gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   colorize

--- a/bin/aicommit
+++ b/bin/aicommit
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require "bundler/setup"
 
 require "optparse"
 require "colorize"

--- a/spells/15_work_on_wsl.md
+++ b/spells/15_work_on_wsl.md
@@ -1,0 +1,86 @@
+SYSTEM:
+ruby expert and windows wsl expert
+
+USER:
+I'm working on a project that should be able to run on all ubuntu system on ruby.
+But on WSL, it seems not working with the magic comment:
+
+bin/aicommit
+```ruby
+#!/usr/bin/env ruby
+
+require "optparse"
+require "colorize"
+require_relative "../lib/aicommit"
+require_relative "../lib/aicommit/version"
+
+options = {}
+parser = OptionParser.new do |op|
+  op.banner = "Usage: aicommit [options]"
+
+  op.on("-v", "--version", "Show version") do |v|
+    options[:version] = v
+  end
+
+  op.on("-c", "--config", "Set OpenAI API token") do |c|
+    options[:config] = c
+  end
+end
+
+parser.parse!
+
+if options[:version]
+  puts Aicommit::VERSION
+elsif options[:config]
+  TokenManager.new.write!("OPENAI_API_TOKEN")
+elsif ARGV.empty?
+  Aicommit.new.run
+else
+  puts parser.help
+end
+```
+
+```stdout
+/mnt/c/Users/J/repository/aicommit develop
+❯ bin/aicommit     
+/usr/bin/env: ‘ruby\r’: No such file or directory
+/mnt/c/Users/J/repository/aicommit develop ?1
+❯
+```
+
+ASSISTANT:
+The issue you are encountering is typically due to the file `bin/aicommit` containing Windows-style line endings (`\r\n`) instead of Unix-style line endings (`\n`). The error message `/usr/bin/env: ‘ruby\r’: No such file or directory` indicates that `env` is trying to execute a command named `ruby\r` (which includes the carriage return character `\r`), but no such command exists.
+
+When you're working with Windows Subsystem for Linux (WSL), it is important to ensure that scripts intended to run in a Linux environment use Unix-style line endings. This can happen if you create or edit the file using a Windows-based text editor that defaults to Windows line endings.
+
+To fix the problem:
+
+1. Convert the line endings to Unix style. You can do this by using a text editor that allows you to change line endings or by using a command-line tool like `dos2unix`:
+
+```bash
+dos2unix bin/aicommit
+```
+
+2. Make sure the file has the right permissions to be executable. If not, you can change the permissions using `chmod`:
+
+```bash
+chmod +x bin/aicommit
+```
+
+3. After converting the line endings and making sure the file is executable, try running the script again in WSL.
+
+You may want to configure your text editor to always use Unix-style line endings for files destined to be run within a Unix-based environment like WSL. If you're using Git, you can also configure it to automatically handle line ending conversions correctly with the following settings:
+
+```bash
+git config --global core.autocrlf input
+```
+
+This tells Git to convert line endings to Unix style when you check in files and avoids changing them when you check out files on a system that uses WSL or Linux. When working solely within Unix-like systems, it's better to disable the line ending conversion completely:
+
+```bash
+git config --global core.autocrlf false
+```
+
+To apply this to a specific repository, omit the `--global` flag and run the commands within the repository's directory.
+
+Please keep in mind that these configurations should be chosen based on your project's requirements and your development environment. If you are sharing a codebase with developers on different platforms, ensure that everyone has a clear understanding of the line ending conventions to be used, and consider documenting the setup in your project's contribution guidelines.

--- a/spells/16_work_without_gem_openai.md
+++ b/spells/16_work_without_gem_openai.md
@@ -1,0 +1,60 @@
+SYSTEM:
+ruby expert and windows wsl expert
+
+USER:
+There are two gems: 'ruby-openai' and 'openai'
+
+But the usage is the same:
+```ruby
+require "openai"
+
+# do things... 
+```
+
+is there any way to check what gem is actually been required? or force it to require the specific gem, say 'ruby-openai'
+
+ASSISTANT:
+In Ruby, if two different gems provide the same filename to be required (like `require "openai"`), the gem that is listed first in your Gemfile (or .gemspec file) or the one that is installed first (if you're not using Bundler) will typically be the one that is loaded. However, this can lead to ambiguity and cause the wrong gem to be required if you're not careful.
+
+To ensure that you are requiring the correct gem, one way is to be explicit in your project's Gemfile by specifying the gem you want to use. 
+
+For example:
+
+```ruby
+# Gemfile
+
+gem 'ruby-openai'
+# gem 'openai' # Comment out or remove the gem you do not want to use.
+```
+
+After modifying your Gemfile, run `bundle install` to install the dependencies accordingly. Be sure to require the gems in your code after requiring 'bundler/setup' to ensure that Bundler sets up the load path correctly.
+
+```ruby
+require 'bundler/setup' 
+Bundler.require
+
+require 'openai'
+
+# do things...
+```
+
+If you're not using Bundler, ensure that only the desired gem is installed in your Ruby environment, or if both gems are needed for different purposes, you might want to manage separate environments using tools like RVM or rbenv.
+
+
+If you find that the wrong gem is being loaded, you can use `$LOAD_PATH` (or its alias `$:`) to check the load path and determine which paths are being searched for the require statement. You could also use `gem which` command to find the location of a specific gem's main file.
+
+```bash
+gem which openai
+```
+
+If there is still ambiguity or if you need to differentiate the same file required by two different gems, you will likely have to either rename the required files within the gems (which would require forking or otherwise modifying the gem, not generally recommended) or work with the maintainers of the gems to resolve the naming conflict.
+
+If you are the creator or a contributor to one of these gems, consider namespacing the require paths with the gem name to avoid such clashes (e.g., `require "ruby-openai/openai"`).
+
+Lastly, there's also the possibility to directly require the file from its install path, although this is more of a hack and might break the conventional use of gems:
+
+```ruby
+require '/path/to/gem/lib/openai.rb'
+```
+
+You would have to replace '/path/to/gem/lib/openai.rb' with the actual path to the gem you want to use. This is not recommended for general use but can serve as a last resort or for debugging purposes.


### PR DESCRIPTION
- In Ruby, if two different gems provide the same filename to be required (like `require "openai"`), the gem that is listed first in your Gemfile (or .gemspec file) or the one that is installed first (if you're not using Bundler) will typically be the one that is loaded.
- However, this can lead to ambiguity and cause the wrong gem to be required if you're not careful.

- To ensure that you are requiring the correct gem, one way is to be explicit in your project's Gemfile by specifying the gem you want to use. Be sure to require the gems in your code after requiring 'bundler/setup' to ensure that Bundler sets up the load path correctly.

```ruby
require 'bundler/setup' 

require 'openai'

# do things...
```