### PR TITLE
ci: update ruby versions in GitHub actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6, 2.7, 3.0, 3.1]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
     steps:
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
#### description
- add ruby versions for ci
- fix incorrect ruby version

#### change
- add new ruby versions:
  - `3.2`
  - `3.3`
- fix incorrect ruby version:
  We set `3.0` in the `test.yml`, but it actually fetches the latest ruby version

before:
<img width="666" alt="image" src="https://github.com/jackal998/aicommit/assets/22932376/95e43323-2586-4319-8ea4-90faf6086d1c">
after:
<img width="666" alt="image" src="https://github.com/jackal998/aicommit/assets/22932376/8f150116-8a7b-4b10-89a9-8cced9e09259">
