### PR TITLE
feat: Enhance PR Description Generation with File and Clipboard Options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,6 +92,22 @@ This will:
    - Proper markdown formatting (headings, lists, code blocks)
 3. Save the approved PR description to a `PR_DESCRIPTION.md` file in your current directory
 
+You can customize the output destination:
+
+```bash
+# Save to a specific filename
+aicommit -p --file my_pr.md
+
+# Copy to clipboard instead of saving to a file
+aicommit -p --clipboard
+
+# Both save to file and copy to clipboard
+aicommit -p --file --clipboard
+
+# Save to a specific file and copy to clipboard
+aicommit -p --file custom_pr.md --clipboard
+```
+
 ## Command-Line Options
 
 - `-v`, `--version`: Show the current version
@@ -99,6 +115,8 @@ This will:
 - `--model`: Set or update the OpenAI model
 - `--base-branch`: Set or update your base branch name
 - `-p [BASE_REF]`, `--pr-description [BASE_REF]`: Generate a PR description, optionally specifying a base reference (branch name or commit SHA)
+- `--file [FILENAME]`: Save PR description to a file (default: `PR_DESCRIPTION.md`)
+- `--clipboard`: Copy PR description to clipboard
 
 ## Security
 

--- a/bin/aicommit
+++ b/bin/aicommit
@@ -21,6 +21,14 @@ parser = OptionParser.new do |op|
     options[:pr_base_ref] = pr
   end
 
+  op.on("--file [FILENAME]", "Save PR description to a file (default: PR_DESCRIPTION.md)") do |filename|
+    options[:file] = filename || true
+  end
+
+  op.on("--clipboard", "Copy PR description to clipboard") do
+    options[:clipboard] = true
+  end
+
   op.on("-v", "--version", "Show version") do |v|
     options[:version] = v
   end
@@ -63,7 +71,10 @@ elsif options[:model]
 elsif options[:base_branch]
   Envs::BaseBranch.new.update!
 elsif options[:pr_description]
-  PrDescriptionGenerator.new(options[:pr_base_ref]).run
+  # By default, save to file if neither option is specified
+  options[:file] = true if !options[:file] && !options[:clipboard]
+
+  PrDescriptionGenerator.new(options[:pr_base_ref], options).run
 elsif ARGV.empty?
   Aicommit.run
 else

--- a/lib/pr_description_generator.rb
+++ b/lib/pr_description_generator.rb
@@ -9,30 +9,58 @@ require_relative "git_client"
 
 class PrDescriptionGenerator
   DIFF_LIMIT = 100000
+  DEFAULT_FILENAME = "PR_DESCRIPTION.md"
 
-  def initialize(base_ref = nil)
+  def initialize(base_ref = nil, options = {})
     @git_client = GitClient.new
     @ai_client = AiClient.new
     @base_ref = base_ref
+    @options = options
   end
 
   def run
     base_ref = @base_ref || Envs::BaseBranch.new.fetch!
     diff = git_client.diff_from_branch_root(base_ref)
     pr_description = ai_client.get_pr_description(diff)
-    save_pr_description(pr_description)
-    puts "PR description has been saved to PR_DESCRIPTION.md"
+
+    output = format_pr_description(pr_description)
+
+    if @options[:file]
+      filename = @options[:file].is_a?(String) ? @options[:file] : DEFAULT_FILENAME
+      save_to_file(output, filename)
+      puts "PR description saved to #{filename}"
+    end
+
+    if @options[:clipboard]
+      copy_to_clipboard(output)
+      puts "PR description copied to clipboard"
+    end
   end
 
   private
 
   attr_reader :git_client, :ai_client
 
-  def save_pr_description(pr_description)
-    File.open("PR_DESCRIPTION.md", "w") do |file|
-      file.puts "# #{pr_description["title"]}"
-      file.puts ""
-      file.puts pr_description["description"]
+  def format_pr_description(pr_description)
+    "# #{pr_description["title"]}\n\n#{pr_description["description"]}"
+  end
+
+  def save_to_file(content, filename)
+    File.open(filename, "w") do |file|
+      file.puts content
+    end
+  end
+
+  def copy_to_clipboard(content)
+    case RbConfig::CONFIG["host_os"]
+    when /darwin/
+      IO.popen("pbcopy", "w") { |f| f << content }
+    when /linux/
+      IO.popen("xclip -selection clipboard", "w") { |f| f << content }
+    when /mswin|mingw/
+      IO.popen("clip", "w") { |f| f << content }
+    else
+      puts "Warning: Clipboard functionality not supported on your OS".yellow
     end
   end
 end

--- a/spec/pr_description_generator_spec.rb
+++ b/spec/pr_description_generator_spec.rb
@@ -14,11 +14,14 @@ RSpec.describe PrDescriptionGenerator do
       "description" => "## Overview\nThis PR implements a new feature.\n\n## Changes\n- Added feature X\n- Fixed bug Y"
     }
   end
+  let(:formatted_output) { "# #{pr_description["title"]}\n\n#{pr_description["description"]}" }
 
   before do
     allow(GitClient).to receive(:new).and_return(git_client)
     allow(AiClient).to receive(:new).and_return(ai_client)
     allow(Envs::BaseBranch).to receive_message_chain(:new, :fetch!).and_return(base_branch)
+    allow(git_client).to receive(:diff_from_branch_root).and_return(diff)
+    allow(ai_client).to receive(:get_pr_description).with(diff).and_return(pr_description)
   end
 
   describe "#initialize" do
@@ -35,15 +38,27 @@ RSpec.describe PrDescriptionGenerator do
         expect(subject.instance_variable_get(:@base_ref)).to eq(commit_sha)
       end
     end
+
+    context "with options parameter" do
+      let(:options) { {file: "custom.md", clipboard: true} }
+      subject { described_class.new(commit_sha, options) }
+
+      it "stores the options" do
+        expect(subject.instance_variable_get(:@options)).to eq(options)
+      end
+    end
   end
 
   describe "#run" do
     before do
       allow(File).to receive(:open).and_yield(StringIO.new)
       allow(StringIO.new).to receive(:puts)
+      allow_any_instance_of(described_class).to receive(:copy_to_clipboard)
     end
 
     context "when no base_ref is specified in the constructor" do
+      subject { described_class.new(nil, {file: true}) }
+
       before do
         allow(git_client).to receive(:diff_from_branch_root).with(base_branch).and_return(diff)
       end
@@ -53,12 +68,12 @@ RSpec.describe PrDescriptionGenerator do
         expect(git_client).to receive(:diff_from_branch_root).with(base_branch).and_return(diff)
         expect(ai_client).to receive(:get_pr_description).with(diff).and_return(pr_description)
 
-        expect { subject.run }.to output(/PR description has been saved to PR_DESCRIPTION.md/).to_stdout
+        expect { subject.run }.to output(/PR description saved to PR_DESCRIPTION.md/).to_stdout
       end
     end
 
     context "when a base_ref is specified in the constructor" do
-      subject { described_class.new(commit_sha) }
+      subject { described_class.new(commit_sha, {file: true}) }
 
       before do
         allow(git_client).to receive(:diff_from_branch_root).with(commit_sha).and_return(diff)
@@ -69,26 +84,127 @@ RSpec.describe PrDescriptionGenerator do
         expect(git_client).to receive(:diff_from_branch_root).with(commit_sha).and_return(diff)
         expect(ai_client).to receive(:get_pr_description).with(diff).and_return(pr_description)
 
-        expect { subject.run }.to output(/PR description has been saved to PR_DESCRIPTION.md/).to_stdout
+        expect { subject.run }.to output(/PR description saved to PR_DESCRIPTION.md/).to_stdout
+      end
+    end
+
+    context "with file option as true" do
+      subject { described_class.new(commit_sha, {file: true}) }
+
+      it "saves to default file" do
+        expect_any_instance_of(described_class).to receive(:save_to_file).with(formatted_output, "PR_DESCRIPTION.md")
+        expect { subject.run }.to output(/PR description saved to PR_DESCRIPTION.md/).to_stdout
+      end
+    end
+
+    context "with file option as string" do
+      let(:custom_filename) { "custom_pr.md" }
+      subject { described_class.new(commit_sha, {file: custom_filename}) }
+
+      it "saves to specified file" do
+        expect_any_instance_of(described_class).to receive(:save_to_file).with(formatted_output, custom_filename)
+        expect { subject.run }.to output(/PR description saved to #{custom_filename}/).to_stdout
+      end
+    end
+
+    context "with clipboard option" do
+      subject { described_class.new(commit_sha, {clipboard: true}) }
+
+      it "copies to clipboard" do
+        expect_any_instance_of(described_class).to receive(:copy_to_clipboard).with(formatted_output)
+        expect { subject.run }.to output(/PR description copied to clipboard/).to_stdout
+      end
+    end
+
+    context "with both file and clipboard options" do
+      let(:custom_filename) { "custom_pr.md" }
+      subject { described_class.new(commit_sha, {file: custom_filename, clipboard: true}) }
+
+      it "saves to file and copies to clipboard" do
+        expect_any_instance_of(described_class).to receive(:save_to_file).with(formatted_output, custom_filename)
+        expect_any_instance_of(described_class).to receive(:copy_to_clipboard).with(formatted_output)
+        expect { subject.run }.to output(/PR description saved to #{custom_filename}/).to_stdout
       end
     end
   end
 
-  describe "#save_pr_description" do
+  describe "#format_pr_description" do
+    it "formats the PR description correctly" do
+      expect(subject.send(:format_pr_description, pr_description)).to eq(formatted_output)
+    end
+  end
+
+  describe "#save_to_file" do
     let(:file) { instance_double(File) }
+    let(:filename) { "output.md" }
 
     before do
       allow(File).to receive(:open).and_yield(file)
       allow(file).to receive(:puts)
     end
 
-    it "writes the PR description to a markdown file" do
-      expect(File).to receive(:open).with("PR_DESCRIPTION.md", "w")
-      expect(file).to receive(:puts).with("# #{pr_description["title"]}")
-      expect(file).to receive(:puts).with("")
-      expect(file).to receive(:puts).with(pr_description["description"])
+    it "writes the content to the specified file" do
+      expect(File).to receive(:open).with(filename, "w")
+      expect(file).to receive(:puts).with(formatted_output)
 
-      subject.send(:save_pr_description, pr_description)
+      subject.send(:save_to_file, formatted_output, filename)
+    end
+  end
+
+  describe "#copy_to_clipboard" do
+    let(:content) { "Test content" }
+    let(:io) { instance_double(IO) }
+
+    context "on macOS" do
+      before do
+        allow(RbConfig::CONFIG).to receive(:[]).with("host_os").and_return("darwin")
+        allow(IO).to receive(:popen).with("pbcopy", "w").and_yield(io)
+        allow(io).to receive(:<<)
+      end
+
+      it "uses pbcopy" do
+        expect(IO).to receive(:popen).with("pbcopy", "w")
+        expect(io).to receive(:<<).with(content)
+        subject.send(:copy_to_clipboard, content)
+      end
+    end
+
+    context "on Linux" do
+      before do
+        allow(RbConfig::CONFIG).to receive(:[]).with("host_os").and_return("linux")
+        allow(IO).to receive(:popen).with("xclip -selection clipboard", "w").and_yield(io)
+        allow(io).to receive(:<<)
+      end
+
+      it "uses xclip" do
+        expect(IO).to receive(:popen).with("xclip -selection clipboard", "w")
+        expect(io).to receive(:<<).with(content)
+        subject.send(:copy_to_clipboard, content)
+      end
+    end
+
+    context "on Windows" do
+      before do
+        allow(RbConfig::CONFIG).to receive(:[]).with("host_os").and_return("mswin")
+        allow(IO).to receive(:popen).with("clip", "w").and_yield(io)
+        allow(io).to receive(:<<)
+      end
+
+      it "uses clip" do
+        expect(IO).to receive(:popen).with("clip", "w")
+        expect(io).to receive(:<<).with(content)
+        subject.send(:copy_to_clipboard, content)
+      end
+    end
+
+    context "on unsupported OS" do
+      before do
+        allow(RbConfig::CONFIG).to receive(:[]).with("host_os").and_return("unknown")
+      end
+
+      it "shows a warning" do
+        expect { subject.send(:copy_to_clipboard, content) }.to output(/Warning: Clipboard functionality not supported/).to_stdout
+      end
     end
   end
 end


### PR DESCRIPTION
## Overview
This PR enhances the PR description generation tool by adding options to save the generated description to a specified file and copy it to the clipboard.

## Changes
- Updated the command-line interface to accept `--file [FILENAME]` to save the PR description to a specified file (default is `PR_DESCRIPTION.md`).
- Introduced `--clipboard` option to copy the PR description directly to the clipboard.
- Modified the `PrDescriptionGenerator` class to handle these new options, including saving the output and copying to clipboard functionality based on the user's choice.

## Technical Details
- The `PrDescriptionGenerator` now accepts an `options` parameter to manage file and clipboard options. If neither option is specified, it defaults to saving to `PR_DESCRIPTION.md`.
- Clipboard functionality is implemented using platform-specific commands: `pbcopy` for macOS, `xclip` for Linux, and `clip` for Windows.
- Added tests to ensure that the new features are functioning correctly, including handling different operating systems.

## Testing
New tests cover the functionality for both saving to a file with a custom name and copying the output to the clipboard. These tests ensure that the PR description is formatted correctly and that the appropriate actions are taken based on the provided options.